### PR TITLE
Massive rename of the script file names

### DIFF
--- a/docs/datapipeline.rst
+++ b/docs/datapipeline.rst
@@ -23,7 +23,7 @@ Before we start using ImagingLSS, it is crucial to build the catalogue cache.
     .. code-block:: bash
        	/project/projectdirs/m779/imaginglss/dr2.conf.py
 
-The application to build the cache is :code:`scripts/build_cache.py`. The application
+The application to build the cache is :code:`scripts/imglss-mpi-build-cache.py`. The application
 scans the files in the data release described by a configuration file (provided in
 :code:`--conf` argument), and converts the columns used by ImagingLSS to a binary 
 format that is much easier to use into the 'cache' directory specified in the configuration
@@ -33,7 +33,7 @@ The inline help of the script describes the usage:
 
 .. code-block:: bash
 
-    usage: build_cache.py [-h] [--conf CONF]
+    usage: imglss-mpi-build-cache.py [-h] [--conf CONF]
 
     optional arguments:
       -h, --help   show this help message and exit
@@ -46,9 +46,9 @@ Submit the job script with :code:`sbatch`.
 .. code-block:: bash
 
     #!/bin/bash
-    #SBATCH -J build_cache
+    #SBATCH -J imglss-mpi-build-cache
     #SBATCH -n 512
-    #SBATCH -o build_cache.%j
+    #SBATCH -o imglss-mpi-build-cache.%j
     #SBATCH -p debug
     #SBATCH -t 00:30:00
 
@@ -61,12 +61,12 @@ Submit the job script with :code:`sbatch`.
     mirror ~/source/imaginglss imaginglss scripts
 
     # change conf to your imaginglss configuration file
-    srun -n 256 python-mpi /dev/shm/local/scripts/build_cache.py --conf /project/projectdirs/m779/imaginglss/dr2.conf.py
+    srun -n 256 python-mpi /dev/shm/local/scripts/imglss-mpi-build-cache.py --conf /project/projectdirs/m779/imaginglss/dr2.conf.py
     
 Generating Object Catalogue
 ---------------------------
 
-:code:`scripts/select_objs.py` selects objects of a type, and writes out the objects
+:code:`scripts/imglss-mpi-select-objects.py` selects objects of a type, and writes out the objects
 that we will use in the LSS catalogue.
 
 The target types are defined at http://desi.lbl.gov/trac/wiki/TargetSelection
@@ -78,7 +78,7 @@ The inline help of the script describes the usage:
 
 .. code-block:: bash
 
-    usage: select_objs.py [-h] [--sigma-z SIGMA_Z] [--sigma-g SIGMA_G]
+    usage: imglss-mpi-select-objects.py [-h] [--sigma-z SIGMA_Z] [--sigma-g SIGMA_G]
                           [--sigma-r SIGMA_R]
                           [--with-tycho {BOSS_DR9,DECAM_BGS,DECAM_ELG,DECAM_LRG,DECAM_QSO}]
                           [--conf CONF]
@@ -109,9 +109,9 @@ one by one from an interactive job session, obtained via :code:`salloc`. Refer t
 
     #!/bin/bash
 
-    #SBATCH -J select_objs
+    #SBATCH -J imglss-mpi-select-objects
     #SBATCH -n 512
-    #SBATCH -o select_objs.%j
+    #SBATCH -o imglss-mpi-select-objects.%j
     #SBATCH -p debug
     #SBATCH -t 00:30:00
 
@@ -127,13 +127,13 @@ one by one from an interactive job session, obtained via :code:`salloc`. Refer t
     export PYTHONPATH=/dev/shm/local:$PYTHONPATH
 
     # change conf to your imaginglss configuration file
-    srun -n 256 python-mpi /dev/shm/local/scripts/select_objs.py LRG LRG.txt --with-tycho DECAM_LRG --conf /project/projectdirs/m779/imaginglss/dr2.conf.py
+    srun -n 256 python-mpi /dev/shm/local/scripts/imglss-mpi-select-objects.py LRG LRG.txt --with-tycho DECAM_LRG --conf /project/projectdirs/m779/imaginglss/dr2.conf.py
 
 
 Generating Complete Random Sky Mask
 -----------------------------------
 
-make_random.py generates the randoms for the sky mask of a target type.
+imglss-mpi-make-random.py generates the randoms for the sky mask of a target type.
 
 The output is the RA DEC and magnitudes limit at that location on the sky. 
 There is an option to use the Tycho star catalogue to veto regions near a known star.
@@ -142,7 +142,7 @@ The inline help of the script describes the usage:
 
 .. code-block:: bash
 
-    usage: make_random.py [-h] [--sigma-z SIGMA_Z] [--sigma-g SIGMA_G]
+    usage: imglss-mpi-make-random.py [-h] [--sigma-z SIGMA_Z] [--sigma-g SIGMA_G]
                           [--sigma-r SIGMA_R]
                           [--with-tycho {BOSS_DR9,DECAM_BGS,DECAM_ELG,DECAM_LRG,DECAM_QSO}]
                           [--conf CONF]
@@ -173,9 +173,9 @@ one by one from an interactive job session, obtained via :code:`salloc`. Refer t
 
     #!/bin/bash
 
-    #SBATCH -J make_random
+    #SBATCH -J imglss-mpi-make-random
     #SBATCH -n 512
-    #SBATCH -o make_random.%j
+    #SBATCH -o imglss-mpi-make-random.%j
     #SBATCH -p debug
     #SBATCH -t 00:30:00
 
@@ -191,4 +191,4 @@ one by one from an interactive job session, obtained via :code:`salloc`. Refer t
     export PYTHONPATH=/dev/shm/local:$PYTHONPATH
 
     # change conf to your imaginglss configuration file
-    srun -n 256 python-mpi /dev/shm/local/scripts/make_random.py 6000000 QSO QSO_rand.txt --with-tycho DECAM_QSO --conf /project/projectdirs/m779/imaginglss/dr2.conf.py
+    srun -n 256 python-mpi /dev/shm/local/scripts/imglss-mpi-make-random.py 6000000 QSO QSO_rand.txt --with-tycho DECAM_QSO --conf /project/projectdirs/m779/imaginglss/dr2.conf.py

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -22,7 +22,7 @@ http://nbviewer.ipython.org/urls/imaginglss-git.s3.amazonaws.com/RandomMaskELG.i
 
 .. attention:: 
 
-    Note that the LSS generation pipe line (select_objs.py, make_randoms.py) 
+    Note that the part of the LSS generation pipe line (files in scripts/imglss-mpi-*.py ) 
     typically requires a high-throughput operation querying a large amount of data, 
     these cannot be done with notebook. The notebooks are most useful for inspecting
     smaller chunks of data, individual bricks, etc. Refer to :doc:`datapipeline`.

--- a/nersc/build_cache.job
+++ b/nersc/build_cache.job
@@ -15,7 +15,7 @@ mirror ../ imaginglss scripts
 # use without installing
 export PYTHONPATH=/dev/shm/local:$PYTHONPATH
 
-srun -n 256 python-mpi /dev/shm/local/scripts/build_cache.py --conf /project/projectdirs/m779/imaginglss/dr2.conf.py
+srun -n 256 python-mpi /dev/shm/local/scripts/imglss-mpi-build-cache.py --conf /project/projectdirs/m779/imaginglss/dr2.conf.py
 
 
 

--- a/nersc/make_random.job
+++ b/nersc/make_random.job
@@ -16,7 +16,7 @@ mirror ../ imaginglss scripts
 # use without installing
 export PYTHONPATH=/dev/shm/local:$PYTHONPATH
 
-srun -n 256 python-mpi /dev/shm/local/scripts/make_random.py 6000000 LRG_rand.txt --with-tycho DECAM_LRG --conf /project/projectdirs/m779/imaginglss/dr2.conf.py
+srun -n 256 python-mpi /dev/shm/local/scripts/imglss-mpi-make-random.py 6000000 LRG_rand.txt --with-tycho DECAM_LRG --conf /project/projectdirs/m779/imaginglss/dr2.conf.py
 
 #srun -n 256 python-mpi /dev/shm/local/scripts/make_random.py 400000 ELG_rand.txt --with-tycho DECAM_ELG --conf /project/projectdirs/m779/imaginglss/dr2.conf.py
 

--- a/nersc/select_objs.job
+++ b/nersc/select_objs.job
@@ -17,7 +17,7 @@ mirror ../ imaginglss scripts
 # use without installing
 export PYTHONPATH=/dev/shm/local:$PYTHONPATH
 
-srun -n 256 python-mpi /dev/shm/local/scripts/select_objs.py LRG LRG.txt --with-tycho DECAM_LRG --conf /project/projectdirs/m779/imaginglss/dr2.conf.py
+srun -n 256 python-mpi /dev/shm/local/scripts/imglss-mpi-select-objects.py LRG LRG.txt --with-tycho DECAM_LRG --conf /project/projectdirs/m779/imaginglss/dr2.conf.py
 
 #srun -n 256 python-mpi /dev/shm/local/scripts/select_objs.py ELG ELG.txt --with-tycho DECAM_ELG --conf /project/projectdirs/m779/imaginglss/dr2.conf.py
 

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,14 +1,14 @@
 
-python scripts/build_cache.py --conf=testdata/dr2-mini/dr2.conf.py || exit 1
-python scripts/select_objs.py --conf=testdata/dr2-mini/dr2.conf.py QSO QSO.txt || exit 1
+python scripts/imglss-mpi-build-cache.py --conf=testdata/dr2-mini/dr2.conf.py || exit 1
+python scripts/imglss-mpi-select-objects.py --conf=testdata/dr2-mini/dr2.conf.py QSO QSO.txt || exit 1
 head QSO.txt.NOISES
 head QSO.txt.FLUXES
-python scripts/select_objs.py --conf=testdata/dr2-mini/dr2.conf.py QSO QSO.hdf5 || exit 1
-python scripts/make_random.py --conf=testdata/dr2-mini/dr2.conf.py 1000 QSO-random.txt || exit 1
+python scripts/imglss-mpi-select-objects.py --conf=testdata/dr2-mini/dr2.conf.py QSO QSO.hdf5 || exit 1
+python scripts/imglss-mpi-make-random.py --conf=testdata/dr2-mini/dr2.conf.py 1000 QSO-random.txt || exit 1
 head QSO-random.txt.NOISES
-python scripts/make_random.py --conf=testdata/dr2-mini/dr2.conf.py 1000 QSO-random.hdf5 || exit 1
+python scripts/imglss-mpi-make-random.py --conf=testdata/dr2-mini/dr2.conf.py 1000 QSO-random.hdf5 || exit 1
 
-python scripts/query_completeness.py --conf=testdata/dr2-mini/dr2.conf.py QSO QSO-random.txt QSO.txt QSO-random.txt || exit 1
+python scripts/imglss-query-completeness.py --conf=testdata/dr2-mini/dr2.conf.py QSO QSO-random.txt QSO.txt QSO-random.txt || exit 1
 head QSO-random.txt.FC
-python scripts/query_tycho_veto.py --conf=testdata/dr2-mini/dr2.conf.py QSO-random.txt QSO-random.txt|| exit 1
+python scripts/imglss-query-tycho-veto.py --conf=testdata/dr2-mini/dr2.conf.py QSO-random.txt QSO-random.txt|| exit 1
 head QSO-random.txt.TYCHOVETO

--- a/scripts/imglss-mpi-build-cache.py
+++ b/scripts/imglss-mpi-build-cache.py
@@ -17,7 +17,7 @@ import numpy
 
 from argparse import ArgumentParser
 
-ap = ArgumentParser("build_cache.py")
+ap = ArgumentParser()
 ap.add_argument("--conf", default=None, 
         help="Path to the imaginglss config file, default is from DECALS_PY_CONFIG")
 

--- a/scripts/imglss-mpi-make-random.py
+++ b/scripts/imglss-mpi-make-random.py
@@ -20,7 +20,7 @@ from   imaginglss             import DECALS
 
 from argparse import ArgumentParser
 
-ap = ArgumentParser("make_random.py")
+ap = ArgumentParser()
 ap.add_argument("Nran", type=int, help="Minimum number of randoms")
 ap.add_argument("output", type=output.writer)
 ap.add_argument("--conf", default=None,

--- a/scripts/imglss-mpi-select-objects.py
+++ b/scripts/imglss-mpi-select-objects.py
@@ -26,7 +26,7 @@ from imaginglss.utils       import output
 
 from argparse import ArgumentParser
 
-ap = ArgumentParser("select_objs.py")
+ap = ArgumentParser()
 ap.add_argument("ObjectType", choices=[i for i in targetselection.__all__])
 ap.add_argument("output", type=output.writer)
 ap.add_argument("--use-tractor-depth", action='store_true', default=False, help="Use Tractor's Depth in the catalogue, very fast!")

--- a/scripts/imglss-query-completeness.py
+++ b/scripts/imglss-query-completeness.py
@@ -9,7 +9,7 @@ from kdcount import KDTree
 
 from argparse import ArgumentParser
 
-ap = ArgumentParser("query_completeness.py")
+ap = ArgumentParser()
 ap.add_argument("ObjectType", choices=[i for i in targetselection.__all__])
 ap.add_argument("output", type=output.writer)
 ap.add_argument("objects", type=output.writer)

--- a/scripts/imglss-query-tycho-veto.py
+++ b/scripts/imglss-query-tycho-veto.py
@@ -20,7 +20,7 @@ from imaginglss.utils       import output
 
 from argparse import ArgumentParser
 
-ap = ArgumentParser("query_veto.py",
+ap = ArgumentParser("",
 description=
 """
 Query the TYCHOVETO flags of input data. The position is taken from the NOISES extension of input.


### PR DESCRIPTION
- add prefix imglss to the pipeline commands.
- mpi scripts have additional mpi prefix in the names.
- non-mpi scripts (that runs on Edison frontend node do not have such)
  We may eventually add sharedmem parallelism to the non-mpi scripts.
