### PR TITLE
Write targets in turns.

### DIFF
--- a/scripts/imglss-mpi-select-objects.py
+++ b/scripts/imglss-mpi-select-objects.py
@@ -167,10 +167,10 @@ if __name__=="__main__":
         if i != comm.rank :
             continue
 
-    for column in targets.dtype.names:
-        data = comm.gather(targets[column])
+        for column in targets.dtype.names:
+            data = comm.gather(targets[column])
 
-        with h5py.File(ns.output, 'r+') as ff:
-            for column in targets.dtype.names:
-                ff[column][offset:offset+len(targets)] = targets[column]
+            with h5py.File(ns.output, 'r+') as ff:
+                for column in targets.dtype.names:
+                    ff[column][offset:offset+len(targets)] = targets[column]
 


### PR DESCRIPTION
When the gather fails mpi4py due to having too many targets,
we write them in turn to the hdf5 locally instead.